### PR TITLE
Replaced "github.com/cybozu-go/cmd" to "github.com/cybozu-go/well"

### DIFF
--- a/cmd/transocks/main.go
+++ b/cmd/transocks/main.go
@@ -7,15 +7,15 @@ import (
 	"net/url"
 
 	"github.com/BurntSushi/toml"
-	"github.com/cybozu-go/cmd"
 	"github.com/cybozu-go/log"
 	"github.com/cybozu-go/transocks"
+	"github.com/cybozu-go/well"
 )
 
 type tomlConfig struct {
-	Listen   string        `toml:"listen"`
-	ProxyURL string        `toml:"proxy_url"`
-	Log      cmd.LogConfig `toml:"log"`
+	Listen   string         `toml:"listen"`
+	ProxyURL string         `toml:"proxy_url"`
+	Log      well.LogConfig `toml:"log"`
 }
 
 const (
@@ -65,8 +65,8 @@ func serve(lns []net.Listener, c *transocks.Config) {
 	for _, ln := range lns {
 		s.Serve(ln)
 	}
-	err = cmd.Wait()
-	if err != nil && !cmd.IsSignaled(err) {
+	err = well.Wait()
+	if err != nil && !well.IsSignaled(err) {
 		log.ErrorExit(err)
 	}
 }
@@ -79,7 +79,7 @@ func main() {
 		log.ErrorExit(err)
 	}
 
-	g := &cmd.Graceful{
+	g := &well.Graceful{
 		Listen: func() ([]net.Listener, error) {
 			return transocks.Listeners(c)
 		},
@@ -89,8 +89,8 @@ func main() {
 	}
 	g.Run()
 
-	err = cmd.Wait()
-	if err != nil && !cmd.IsSignaled(err) {
+	err = well.Wait()
+	if err != nil && !well.IsSignaled(err) {
 		log.ErrorExit(err)
 	}
 }

--- a/config.go
+++ b/config.go
@@ -7,8 +7,8 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/cybozu-go/cmd"
 	"github.com/cybozu-go/log"
+	"github.com/cybozu-go/well"
 )
 
 const (
@@ -58,9 +58,9 @@ type Config struct {
 	// If nil, the default logger is used.
 	Logger *log.Logger
 
-	// Env can be used to specify a cmd.Environment on which the server runs.
+	// Env can be used to specify a well.Environment on which the server runs.
 	// If nil, the server will run on the global environment.
-	Env *cmd.Environment
+	Env *well.Environment
 }
 
 // NewConfig creates and initializes a new Config.


### PR DESCRIPTION
The "github.com/cybozu-go/cmd" repository has moved to "github.com/cybozu-go/well" at v1.7.0.