### PR TITLE
Replace syscall with golang.org/x/sys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/cybozu-go/netutil v1.2.0
 	github.com/cybozu-go/well v1.8.1
 	golang.org/x/net v0.0.0-20180911220305-26e67e76b6c3
+	golang.org/x/sys v0.0.0-20180906133057-8cf3aee42992
 )

--- a/original_dst_linux.go
+++ b/original_dst_linux.go
@@ -3,9 +3,9 @@
 package transocks
 
 import (
+	syscall "golang.org/x/sys/unix"
 	"net"
 	"os"
-	"syscall"
 	"unsafe"
 )
 


### PR DESCRIPTION
Closes #13 

`syscall` has been deprecated. Use `golang.org/x/sys` instead.
Build and test passed with `GO111MODULE` enabled.