### PR TITLE
Fix log section of sample config

### DIFF
--- a/cmd/transocks/sample.toml
+++ b/cmd/transocks/sample.toml
@@ -5,5 +5,6 @@ listen = "localhost:1081"
 proxy_url = "socks5://10.20.30.40:1080"  # for SOCKS5 server
 #proxy_url = "http://10.20.30.40:3128"   # for HTTP proxy server
 
-log_level = "debug"
-log_file = "/var/log/transocks.log"
+[log]
+level = "debug"
+filename = "/var/log/transocks.log"


### PR DESCRIPTION
Might be useful to compare [tomlConfig struct](https://github.com/cybozu-go/transocks/blob/master/cmd/transocks/main.go) and [LogConfig struct](https://github.com/cybozu-go/well/blob/a60ea150b67df12575c9e56652f1065dfb2c6a3b/log.go).
Steps to reproduce the problem (on fresh env, incl. transocks dependencies):
```
$ go get github.com/cybozu-go/transocks
$ cd cmd/transocks
$ cp sample.toml /etc/transocks.toml
$ go run main.go
2019-04-21T01:03:18.730787Z ihagopian main error: "undecoded key in TOML: [log_level log_file]"
exit status 1
```
Additionally from using _table_, the _file_ field should be _filename_.

BTW, thanks for building _transocks_ and writing the [article](https://ymmt2005.hatenablog.com/entry/2016/03/13/Transparent_SOCKS_proxy_in_Go_to_replace_NAT).

